### PR TITLE
Bugfix - Updates extension rig version

### DIFF
--- a/lib/config/index.html
+++ b/lib/config/index.html
@@ -4,7 +4,7 @@
 
     <title>Muxy Overlay App Rig - Broadcaster Config Page</title>
 
-    <script type="text/javascript" src="//ext-cdn.muxy.io/muxy-extensions-js/1.0.3/muxy-extensions.js"></script>
+    <script type="text/javascript" src="//ext-cdn.muxy.io/muxy-extensions-js/1.0.5/muxy-extensions.js"></script>
   </head>
 
   <body>

--- a/lib/live/index.html
+++ b/lib/live/index.html
@@ -4,7 +4,7 @@
 
     <title>Muxy Overlay App Rig - Broadcaster Live Page</title>
 
-    <script type="text/javascript" src="//ext-cdn.muxy.io/muxy-extensions-js/1.0.3/muxy-extensions.js"></script>
+    <script type="text/javascript" src="//ext-cdn.muxy.io/muxy-extensions-js/1.0.5/muxy-extensions.js"></script>
   </head>
 
   <body>

--- a/lib/viewer/index.html
+++ b/lib/viewer/index.html
@@ -6,7 +6,7 @@
 
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans">
 
-    <script type="text/javascript" src="//ext-cdn.muxy.io/muxy-extensions-js/1.0.3/muxy-extensions.js"></script>
+    <script type="text/javascript" src="//ext-cdn.muxy.io/muxy-extensions-js/1.0.5/muxy-extensions.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
## Overview

Fixes issue where the overlay rig would not build correctly due to it pointing to a bad version of the extensions rig. Update from `1.0.3` => `1.0.5`


**References** 

- See https://github.com/muxy/extensions-rig/issues/3 for extensions rig's original issue